### PR TITLE
feat: user-service 기본 인증 시스템 & HttpOnly 쿠키 연결

### DIFF
--- a/user-service/src/main/java/com/momnect/userservice/command/controller/AuthController.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/controller/AuthController.java
@@ -89,12 +89,11 @@ public class AuthController {
     }
 
     /**
-     * 리프레쉬
+     * 토큰 재발급 (AccessToken 갱신)
      *
-     * @param request 로그인 요청 DTO
-     * @return AccessToken + RefreshToken + UserDTO
+     * @param refreshToken HttpOnly 쿠키에서 추출한 RefreshToken
+     * @return 새로운 AccessToken이 설정된 응답 (쿠키)
      */
-
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<Void>> refreshToken(@CookieValue(name = "refreshToken", required = false) String refreshToken) {
 
@@ -113,12 +112,11 @@ public class AuthController {
     }
 
     /**
-     * 쿠키 생성 헬퍼 메서드들
+     * AccessToken HttpOnly 쿠키 생성 헬퍼 메서드
      *
-     * @param request 로그인 요청 DTO
-     * @return AccessToken + RefreshToken + UserDTO
+     * @param accessToken JWT AccessToken 문자열
+     * @return HttpOnly AccessToken 쿠키
      */
-
     private ResponseCookie createAccessTokenCookie(String accessToken) {
         return ResponseCookie.from("accessToken", accessToken)
                 .httpOnly(true)                 // XSS 방지

--- a/user-service/src/main/java/com/momnect/userservice/command/controller/AuthController.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/controller/AuthController.java
@@ -3,14 +3,20 @@ package com.momnect.userservice.command.controller;
 import com.momnect.userservice.command.dto.LoginRequest;
 import com.momnect.userservice.command.dto.LoginResponse;
 import com.momnect.userservice.command.dto.SignupRequest;
+import com.momnect.userservice.command.dto.UserDTO;
 import com.momnect.userservice.command.service.AuthService;
+import com.momnect.userservice.common.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Duration;
 
 @Validated
 @Tag(name = "Auth API", description = "유저 인증 관련 기능을 제공합니다.")
@@ -26,8 +32,17 @@ public class AuthController {
      * @return 로그인 후 발급되는 AccessToken + RefreshToken + UserDTO
      */
     @PostMapping("/signup")
-    public LoginResponse signup(@RequestBody SignupRequest request) {
-        return authService.signup(request);
+    public ResponseEntity<ApiResponse<UserDTO>> signup(@Valid @RequestBody SignupRequest request) {
+        LoginResponse loginResponse = authService.signup(request);
+
+        // HttpOnly 쿠키 설정
+        ResponseCookie accessTokenCookie = createAccessTokenCookie(loginResponse.getAccessToken());
+        ResponseCookie refreshTokenCookie = createRefreshTokenCookie(loginResponse.getRefreshToken());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .body(ApiResponse.success(loginResponse.getUser()));
     }
 
     /**
@@ -37,7 +52,100 @@ public class AuthController {
      * @return AccessToken + RefreshToken + UserDTO
      */
     @PostMapping("/login")
-    public LoginResponse login(@RequestBody LoginRequest request) {
-        return authService.login(request.getLoginId(), request.getPassword());
+    public ResponseEntity<ApiResponse<UserDTO>> login(@Valid @RequestBody LoginRequest request) {
+        LoginResponse loginResponse = authService.login(request.getLoginId(), request.getPassword());
+
+        // HttpOnly 쿠키 설정
+        ResponseCookie accessTokenCookie = createAccessTokenCookie(loginResponse.getAccessToken());
+        ResponseCookie refreshTokenCookie = createRefreshTokenCookie(loginResponse.getRefreshToken());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .body(ApiResponse.success(loginResponse.getUser()));
+    }
+
+    /**
+     * 로그아웃
+     *
+     * @param request 로그인 요청 DTO
+     * @return AccessToken + RefreshToken + UserDTO
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(HttpServletRequest request) {
+        String userId = request.getHeader("X-User-Id");
+        if(userId != null) {
+            authService.logout(Long.parseLong(userId));
+        }
+
+        // 쿠키 삭제
+        ResponseCookie accessTokenCookie = createExpiredCookie("accessToken");
+        ResponseCookie refreshTokenCookie = createExpiredCookie("refreshToken");
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .body(ApiResponse.success(null));
+    }
+
+    /**
+     * 리프레쉬
+     *
+     * @param request 로그인 요청 DTO
+     * @return AccessToken + RefreshToken + UserDTO
+     */
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<Void>> refreshToken(@CookieValue(name = "refreshToken", required = false) String refreshToken) {
+
+        if(refreshToken == null) {
+            throw new RuntimeException("refreshToken is null");
+        }
+
+        String newAccessToken = authService.refreshAccessToken(refreshToken);
+
+        // 새로운 AccessToken 쿠키 설정
+        ResponseCookie accessTokenCookie = createAccessTokenCookie(newAccessToken);
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+                .body(ApiResponse.success(null));
+    }
+
+    /**
+     * 쿠키 생성 헬퍼 메서드들
+     *
+     * @param request 로그인 요청 DTO
+     * @return AccessToken + RefreshToken + UserDTO
+     */
+
+    private ResponseCookie createAccessTokenCookie(String accessToken) {
+        return ResponseCookie.from("accessToken", accessToken)
+                .httpOnly(true)                 // XSS 방지
+                .secure(false)                  // 개발환경에서는 false, 운영환경에서는 true
+                .sameSite("Lax")                // CSRF 방지
+                .path("/")                      // 전체 경로에서 사용
+                .maxAge(Duration.ofHours(1))    // 1시간 (향후 30분으로 변경 예정)
+                .build();
+    }
+
+    private ResponseCookie createRefreshTokenCookie(String refreshToken) {
+        return ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)                 // XSS 방지
+                .secure(false)                  // 개발환경에서는 false, 운영환경에서는 true
+                .sameSite("Lax")                // CSRF 방지
+                .path("/")                      // 전체 경로에서 사용
+                .maxAge(Duration.ofDays(7))     // 7일
+                .build();
+    }
+
+    private ResponseCookie createExpiredCookie(String cookieName) {
+        return ResponseCookie.from(cookieName, "")
+                .httpOnly(true)
+                .secure(false)
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(Duration.ZERO)             // 즉시 만료
+                .build();
     }
 }

--- a/user-service/src/main/java/com/momnect/userservice/command/controller/UserController.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/controller/UserController.java
@@ -1,0 +1,137 @@
+package com.momnect.userservice.command.controller;
+
+import com.momnect.userservice.command.dto.*;
+import com.momnect.userservice.command.service.UserService;
+import com.momnect.userservice.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import jakarta.servlet.http.HttpServletRequest;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+
+    private final UserService userService;
+
+    /**
+     * 헤더용 기본 정보 (닉네임, 이미지만)
+     */
+    @GetMapping("/{userId}/basic")
+    public ResponseEntity<ApiResponse<PublicUserDTO>> getBasicInfo(@PathVariable Long userId) {
+        PublicUserDTO userInfo = userService.getPublicUserProfile(userId);
+        return ResponseEntity.ok(ApiResponse.success(userInfo));
+    }
+
+    /**
+     * 사용자 존재 여부 확인
+     */
+    @GetMapping("/{userId}/exists")
+    public ResponseEntity<ApiResponse<Boolean>> checkUserExists(@PathVariable Long userId) {
+        boolean exists = userService.checkUserExists(userId);
+        return ResponseEntity.ok(ApiResponse.success(exists));
+    }
+
+    /**
+     * 마이페이지 기본 정보 (닉네임, 이미지만) - 프론트엔드용
+     * 자녀정보는 자녀관리 API 완성 후 제거 예정
+     */
+    @Operation(summary = "마이페이지 기본 정보", description = "프로필 정보를 조회합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<PublicUserDTO>> getMyInfo(HttpServletRequest request) {
+        Long userId = getUserIdFromRequest(request);
+        PublicUserDTO userInfo = userService.getPublicUserProfile(userId);
+        return ResponseEntity.ok(ApiResponse.success(userInfo));
+
+        // TODO: 자녀관리 API 완성 후 자녀 정보 추가
+        // TODO: 프론트엔드에서 자녀관리 API 별도 호출로 변경
+    }
+
+    /**
+     * 타사용자 기본 정보 (닉네임, 이미지만) - 프론트엔드용
+     */
+    @Operation(summary = "타사용자 기본 정보", description = "공개 프로필 정보를 조회합니다.")
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiResponse<PublicUserDTO>> getUserInfo(@PathVariable Long userId) {
+        PublicUserDTO userInfo = userService.getPublicUserProfile(userId);
+        return ResponseEntity.ok(ApiResponse.success(userInfo));
+    }
+
+    /**
+     * 프로필 수정용 정보 조회
+     */
+    @GetMapping("/me/profile")
+    public ResponseEntity<ApiResponse<UserDTO>> getProfileForEdit(HttpServletRequest request) {
+        Long userId = getUserIdFromRequest(request);
+        UserDTO profileInfo = userService.getProfileForEdit(userId);
+        return ResponseEntity.ok(ApiResponse.success(profileInfo));
+    }
+
+    /**
+     * 프로필 수정
+     */
+    @PutMapping("/profile")
+    public ResponseEntity<ApiResponse<UserDTO>> updateProfile(
+            @Valid @RequestBody UpdateProfileRequest request,
+            HttpServletRequest httpRequest) {
+        Long userId = getUserIdFromRequest(httpRequest);
+        UserDTO updatedUser = userService.updateProfile(userId, request);
+        return ResponseEntity.ok(ApiResponse.success(updatedUser));
+    }
+
+    /**
+     * 비밀번호 변경
+     */
+    @PutMapping("/password")
+    public ResponseEntity<ApiResponse<Void>> changePassword(
+            @Valid @RequestBody ChangePasswordRequest request,
+            HttpServletRequest httpRequest) {
+        if (!request.isPasswordMatched()) {
+            throw new RuntimeException("새 비밀번호가 일치하지 않습니다.");
+        }
+        Long userId = getUserIdFromRequest(httpRequest);
+        userService.changePassword(userId, request);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    /**
+     * 회원탈퇴
+     */
+    @DeleteMapping("/account")
+    public ResponseEntity<ApiResponse<Void>> deleteAccount(
+            @Valid @RequestBody DeleteAccountRequest request,
+            HttpServletRequest httpRequest) {
+        Long userId = getUserIdFromRequest(httpRequest);
+        userService.deleteAccount(userId, request);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    /**
+     * 중복 확인
+     */
+    @GetMapping("/check")
+    public ResponseEntity<ApiResponse<CheckDuplicateResponse>> checkDuplicate(
+            @RequestParam String type,
+            @RequestParam String value) {
+        boolean isDuplicate = userService.checkDuplicate(type, value);
+        CheckDuplicateResponse response = new CheckDuplicateResponse(type, value, isDuplicate);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    private Long getUserIdFromRequest(HttpServletRequest request) {
+        String userIdHeader = request.getHeader("X-User-Id");
+        if (userIdHeader != null) {
+            return Long.parseLong(userIdHeader);
+        }
+
+        Object userIdAttr = request.getAttribute("X-User-Id");
+        if (userIdAttr != null) {
+            return Long.parseLong(userIdAttr.toString());
+        }
+
+        throw new RuntimeException("사용자 인증 정보를 찾을 수 없습니다.");
+    }
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/dto/ChangePasswordRequest.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/dto/ChangePasswordRequest.java
@@ -1,0 +1,27 @@
+package com.momnect.userservice.command.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ChangePasswordRequest {
+
+    @NotBlank(message = "현재 비밀번호를 입력해주세요")
+    private final String currentPassword;
+
+    @NotBlank(message = "새 비빌번호를 입력해주세요")
+    @Size(min = 8,max = 16, message = "새 비밀번호를 입력해주세요")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*(),.?\"{}|<>]).{8,16}$", message = "비밀번호는 영문자, 숫자, 특수문자를 포함해야 합니다")
+    private final String newPassword;
+
+    @NotBlank(message = "새 비밀번호 확인을 입력해주세요")
+    private final String newPasswordConfirm;
+
+    public boolean isPasswordMatched() {
+        return newPassword != null && newPassword.equals(newPasswordConfirm);
+    }
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/dto/CheckDuplicateResponse.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/dto/CheckDuplicateResponse.java
@@ -1,0 +1,38 @@
+package com.momnect.userservice.command.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CheckDuplicateResponse {
+    private final String type;          // "loginId", "nickname", "email"
+    private final String value;         // 확인한 값
+    private final boolean isDuplicate;  // 중복 여부
+    private final String message;
+
+    public CheckDuplicateResponse(String type, String value, boolean isDuplicate) {
+        this.type = type;
+        this.value = value;
+        this.isDuplicate = isDuplicate;
+        this.message = generateMessage(type, isDuplicate);
+    }
+
+    private String generateMessage(String type, boolean isDuplicate) {
+        if (isDuplicate) {
+            return switch (type.toLowerCase()) {
+                case "loginid" -> "이미 사용 중인 로그인 ID입니다.";
+                case "nickname" -> "이미 사용 중인 닉네임입니다.";
+                case "email" -> "이미 사용 중인 이메일입니다.";
+                default -> "중복된 값입니다.";
+            };
+        } else {
+            return switch (type.toLowerCase()) {
+                case "loginid" -> "사용 가능한 로그인 ID입니다.";
+                case "nickname" -> "사용 가능한 닉네임입니다.";
+                case "email" -> "사용 가능한 이메일입니다.";
+                default -> "사용 가능합니다.";
+            };
+        }
+    }
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/dto/DeleteAccountRequest.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/dto/DeleteAccountRequest.java
@@ -1,0 +1,15 @@
+package com.momnect.userservice.command.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class DeleteAccountRequest {
+
+    private final String password; // 소셜 로그인 시 null 가능
+
+    @NotNull(message = "탈퇴 동의는 필수입니다")
+    private final Boolean isWithdrawalAgreed;
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/dto/PublicUserDTO.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/dto/PublicUserDTO.java
@@ -1,0 +1,16 @@
+package com.momnect.userservice.command.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PublicUserDTO {
+    // 타 사용자 프로필용
+    private Long id;
+    private String nickname;
+    private String profileImageUrl;
+    private LocalDateTime createdAt;
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/dto/UpdateProfileRequest.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/dto/UpdateProfileRequest.java
@@ -1,0 +1,23 @@
+package com.momnect.userservice.command.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UpdateProfileRequest {
+
+    @Size(max = 15, message = "닉네임은 15자 이하로 입력해주세요")
+    private final String nickname;
+
+    @Email(message = "올바른 이메일 형식으로 입력해주세요")
+    @Size(max = 100,message = "이메일은 100자 이하로 입력해주세요")
+    private final String email;
+
+    @Pattern(regexp = "^010[0-9]{8}$", message = "휴대전화번호는 010으로 시작하는 11자리 숫자로 입력해주세요")
+    private final String phoneNumber;
+
+    private String profileImageUrl;

--- a/user-service/src/main/java/com/momnect/userservice/command/dto/UpdateProfileRequest.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/dto/UpdateProfileRequest.java
@@ -14,10 +14,11 @@ public class UpdateProfileRequest {
     private final String nickname;
 
     @Email(message = "올바른 이메일 형식으로 입력해주세요")
-    @Size(max = 100,message = "이메일은 100자 이하로 입력해주세요")
+    @Size(max = 100, message = "이메일은 100자 이하로 입력해주세요")
     private final String email;
 
     @Pattern(regexp = "^010[0-9]{8}$", message = "휴대전화번호는 010으로 시작하는 11자리 숫자로 입력해주세요")
     private final String phoneNumber;
 
     private String profileImageUrl;
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/mapper/UserMapper.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/mapper/UserMapper.java
@@ -1,0 +1,56 @@
+package com.momnect.userservice.command.mapper;
+
+import com.momnect.userservice.command.dto.UserDTO;
+import com.momnect.userservice.command.dto.PublicUserDTO;
+import com.momnect.userservice.command.entity.User;
+import org.springframework.stereotype.Component;
+
+/**
+ * User 엔티티와 DTO 간 변환을 담당하는 매퍼 클래스
+ * 중복 코드 제거 및 일관된 변환 로직 제공
+ */
+@Component
+public class UserMapper {
+
+    /**
+     * User 엔티티를 UserDTO로 변환 (완전한 정보)
+     * 본인 정보 조회 시 사용
+     */
+    public UserDTO toUserDTO(User user) {
+        return UserDTO.builder()
+                .id(user.getId())
+                .loginId(user.getLoginId())
+                .name(user.getName())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .phoneNumber(user.getPhoneNumber())
+                .address(user.getAddress())
+                .profileImageUrl(user.getProfileImageUrl())
+                .role(user.getRole())
+                .oauthProvider(user.getOauthProvider())
+                .oauthId(user.getOauthId())
+                .isTermsAgreed(user.getIsTermsAgreed())
+                .isPrivacyAgreed(user.getIsPrivacyAgreed())
+                .isWithdrawalAgreed(user.getIsWithdrawalAgreed())
+                .isDeleted(user.getIsDeleted())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
+                .deletedAt(user.getDeletedAt())
+                .createdBy(user.getCreatedBy())
+                .updatedBy(user.getUpdatedBy())
+                .build();
+    }
+
+    /**
+     * User 엔티티를 PublicUserDTO로 변환 (공개 정보만)
+     * 다른 사용자 프로필 조회 시 사용
+     */
+    public PublicUserDTO toPublicUserDTO(User user) {
+        return PublicUserDTO.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .profileImageUrl(user.getProfileImageUrl())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/repository/UserRepository.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/repository/UserRepository.java
@@ -9,13 +9,19 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    // 기본 조회 메서드들
     Optional<User> findByLoginId(String loginId);
-
     Optional<User> findByRefreshToken(String refreshToken);
-
-    // 이메일 중복 체크용
     Optional<User> findByEmail(String email);
-
     // OAuth 사용자 찾기용 (향후 카카오 로그인 확장시)
     Optional<User> findByOauthProviderAndOauthId(String oauthProvider, String oauthId);
+
+    // 증복 검사 메서드들 (본인 제외)
+    boolean existsByNicknameAndIdNot(String nickname, Long id);
+    boolean existsByEmailAndIdNot(String email, Long id);
+
+    // 일반 중복 검사 메서드들
+    boolean existsByLoginId(String loginId);
+    boolean existsByNickname(String nickname);
+    boolean existsByEmail(String email);
 }

--- a/user-service/src/main/java/com/momnect/userservice/command/service/AuthService.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/service/AuthService.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.momnect.userservice.command.mapper.UserMapper;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +21,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
+    private final UserMapper userMapper;
 
     /**
      * 로그인: loginId + password 검증 후 AccessToken, RefreshToken 발급
@@ -38,7 +40,7 @@ public class AuthService {
         user.setRefreshToken(refreshToken);
         userRepository.save(user);
 
-        UserDTO userDTO = convertToUserDTO(user);
+        UserDTO userDTO = userMapper.toUserDTO(user);
         return new LoginResponse(accessToken, refreshToken, userDTO);
     }
 
@@ -69,7 +71,7 @@ public class AuthService {
         user.setRefreshToken(refreshToken);
         userRepository.save(user);
 
-        UserDTO userDTO = convertToUserDTO(user);
+        UserDTO userDTO = userMapper.toUserDTO(user);
         return new LoginResponse(accessToken, refreshToken, userDTO);
     }
 
@@ -101,7 +103,7 @@ public class AuthService {
     /**
      * AccessToken 재발급
      */
-    public String refreshToken(String refreshToken) {
+    public String refreshAccessToken(String refreshToken) {
         // RefreshToken 유효성 검증
         if (!jwtTokenProvider.validateToken(refreshToken)) {
             throw new RuntimeException("유효하지 않은 Refresh token 입니다");
@@ -155,34 +157,6 @@ public class AuthService {
                 .isDeleted(false)
                 .createdBy(0L) // 임시값, 저장 후 실제 ID로 업데이트
                 .updatedBy(0L) // 임시값, 저장 후 실제 ID로 업데이트
-                .build();
-    }
-
-    /**
-     * User 엔티티를 UserDTO로 변환
-     */
-    private UserDTO convertToUserDTO(User user) {
-        return UserDTO.builder()
-                .id(user.getId())
-                .loginId(user.getLoginId())
-                .name(user.getName())
-                .role(user.getRole())
-                .oauthProvider(user.getOauthProvider())
-                .oauthId(user.getOauthId())
-                .email(user.getEmail())
-                .phoneNumber(user.getPhoneNumber())
-                .nickname(user.getNickname())
-                .profileImageUrl(user.getProfileImageUrl())
-                .address(user.getAddress())
-                .createdAt(user.getCreatedAt())
-                .updatedAt(user.getUpdatedAt())
-                .deletedAt(user.getDeletedAt())
-                .isDeleted(user.getIsDeleted())
-                .isTermsAgreed(user.getIsTermsAgreed())
-                .isPrivacyAgreed(user.getIsPrivacyAgreed())
-                .isWithdrawalAgreed(user.getIsWithdrawalAgreed())
-                .createdBy(user.getCreatedBy())
-                .updatedBy(user.getUpdatedBy())
                 .build();
     }
 }

--- a/user-service/src/main/java/com/momnect/userservice/command/service/AuthService.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/service/AuthService.java
@@ -30,6 +30,12 @@ public class AuthService {
         User user = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
+        // 탈퇴한 사용자 확인
+        if (user.getIsDeleted()) {
+            throw new RuntimeException("탈퇴한 사용자입니다");
+        }
+
+        // 로그인 시 비밀번호 검증, 평문과 해시를 비교(복원X)
         if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new RuntimeException("Invalid password");
         }

--- a/user-service/src/main/java/com/momnect/userservice/command/service/UserService.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/service/UserService.java
@@ -1,0 +1,70 @@
+package com.momnect.userservice.command.service;
+
+import com.momnect.userservice.command.dto.UserDTO;
+import com.momnect.userservice.command.entity.User;
+import com.momnect.userservice.command.repository.UserRepository;
+import com.momnect.userservice.exception.DuplicateUserException;
+import com.momnect.userservice.exception.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    // 1. 로그아웃 (RefreshToken 케저)
+    public void logout(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        user.setRefreshToken(null);
+        user.setUpdatedBy(userId);
+        userRepository.save(user);
+    }
+
+    // 2. 마이페이지 조회
+    @Transactional(readOnly = true)
+    public UserDTO getUserById(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        if (user.getIsDeleted()) {
+            throw new UserNotFoundException("탈퇴한 사용자입니다.");
+        }
+
+        return convertToUserDTO(user);
+    }
+
+    // 3. 프로필 수정
+    public UserDTO updateProfile(Long userId, UpdateProfileRequest request) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("탈퇴한 사용자입니다."));
+
+        if (user.getIsDeleted()) {
+            throw new UserNotFoundException("탈퇴한 사용자입니다.");
+        }
+
+        // 닉네임 중복 검사 (본인 제외)
+        if (request.getNickname() != null && !request.getNickname().equals(user.getNickname())) {
+            if (userRepository.existsByNicknameAndIdNot(request.getNickname(), userId)) {
+                throw new DuplicateUserException("이미 사용 중인 닉네임입니다.");
+            }
+        }
+
+        // 프로필 업데이트
+        if (request.getNickname() != null) user.setNickname(request.getNickname());
+        if (request.getEmail() != null) user.setEmail(request.getEmail());
+        if (request.getPhoneNumber() != null) {
+            String cleanPhoneNumber = request.getPhoneNumber().replaceAll("[^0-9]","");
+            user.setPhoneNumber(cleanPhoneNumber);
+        }
+
+        user.setUpdatedBy(userId);
+        User savedUser = userRepository.save(user);
+
+        return convertToUserDTO(savedUser);
+    }
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/service/UserService.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/service/UserService.java
@@ -1,7 +1,12 @@
 package com.momnect.userservice.command.service;
 
 import com.momnect.userservice.command.dto.UserDTO;
+import com.momnect.userservice.command.dto.UpdateProfileRequest;
+import com.momnect.userservice.command.dto.ChangePasswordRequest;
+import com.momnect.userservice.command.dto.DeleteAccountRequest;
+import com.momnect.userservice.command.dto.PublicUserDTO;
 import com.momnect.userservice.command.entity.User;
+import com.momnect.userservice.command.mapper.UserMapper;
 import com.momnect.userservice.command.repository.UserRepository;
 import com.momnect.userservice.exception.DuplicateUserException;
 import com.momnect.userservice.exception.UserNotFoundException;
@@ -10,6 +15,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -17,31 +24,14 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final UserMapper userMapper;
 
-    // 1. 로그아웃 (RefreshToken 케저)
-    public void logout(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
-
-        user.setRefreshToken(null);
-        user.setUpdatedBy(userId);
-        userRepository.save(user);
-    }
-
-    // 2. 마이페이지 조회
-    @Transactional(readOnly = true)
-    public UserDTO getUserById(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
-
-        if (user.getIsDeleted()) {
-            throw new UserNotFoundException("탈퇴한 사용자입니다.");
-        }
-
-        return convertToUserDTO(user);
-    }
-
-    // 3. 프로필 수정
+    /**
+     * 1. 프로필 수정 (닉네임, 이메일, 휴대폰번호만)
+     */
     public UserDTO updateProfile(Long userId, UpdateProfileRequest request) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("탈퇴한 사용자입니다."));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
 
         if (user.getIsDeleted()) {
             throw new UserNotFoundException("탈퇴한 사용자입니다.");
@@ -54,17 +44,135 @@ public class UserService {
             }
         }
 
+        // 이메일 중복 검사 (본인 제외)
+        if (request.getEmail() != null && !request.getEmail().equals(user.getEmail())) {
+            if (userRepository.existsByEmailAndIdNot(request.getEmail(), userId)) {
+                throw new DuplicateUserException("이미 사용 중인 이메일입니다.");
+            }
+        }
+
         // 프로필 업데이트
         if (request.getNickname() != null) user.setNickname(request.getNickname());
         if (request.getEmail() != null) user.setEmail(request.getEmail());
         if (request.getPhoneNumber() != null) {
-            String cleanPhoneNumber = request.getPhoneNumber().replaceAll("[^0-9]","");
+            String cleanPhoneNumber = request.getPhoneNumber().replaceAll("[^0-9]", "");
             user.setPhoneNumber(cleanPhoneNumber);
         }
 
         user.setUpdatedBy(userId);
         User savedUser = userRepository.save(user);
 
-        return convertToUserDTO(savedUser);
+        return userMapper.toUserDTO(savedUser);
+    }
+
+    /**
+     * 2. 비밀번호 변경
+     */
+    public void changePassword(Long userId, ChangePasswordRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        if (user.getIsDeleted()) {
+            throw new UserNotFoundException("탈퇴한 사용자입니다.");
+        }
+
+        // 소셜 로그인 사용자는 비밀번호 변경 불가
+        if (!"LOCAL".equals(user.getOauthProvider())) {
+            throw new RuntimeException("소셜 로그인 사용자는 비밀번호를 변경할 수 없습니다.");
+        }
+
+        // 현재 비밀번호 확인
+        if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
+            throw new RuntimeException("현재 비밀번호가 일치하지 않습니다.");
+        }
+
+        // 새 비밀번호 설정
+        user.setPassword(passwordEncoder.encode(request.getNewPassword()));
+        user.setUpdatedBy(userId);
+        userRepository.save(user);
+    }
+
+    /**
+     * 3. 회원탈퇴
+     */
+    public void deleteAccount(Long userId, DeleteAccountRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        if (user.getIsDeleted()) {
+            throw new UserNotFoundException("이미 탈퇴한 사용자입니다.");
+        }
+
+        // 비밀번호 확인 (소셜 로그인 사용자는 제외)
+        if ("LOCAL".equals(user.getOauthProvider())) {
+            if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+                throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+            }
+        }
+
+        // 탈퇴 처리
+        user.setIsDeleted(true);
+        user.setDeletedAt(LocalDateTime.now());
+        user.setIsWithdrawalAgreed(request.getIsWithdrawalAgreed());
+        user.setRefreshToken(null); // 토큰 제거
+        user.setUpdatedBy(userId);
+
+        userRepository.save(user);
+    }
+
+    /**
+     * 4. 타 사용자 프로필 조회 (공개 정보만)
+     */
+    @Transactional(readOnly = true)
+    public PublicUserDTO getPublicUserProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        if (user.getIsDeleted()) {
+            throw new UserNotFoundException("탈퇴한 사용자입니다.");
+        }
+
+        return userMapper.toPublicUserDTO(user);
+    }
+
+    /**
+     * 5. 중복 확인 (통합 API용)
+     */
+    public boolean checkDuplicate(String type, String value) {
+        switch (type.toLowerCase()) {
+            case "loginid":
+                return userRepository.existsByLoginId(value);
+            case "nickname":
+                return userRepository.existsByNickname(value);
+            case "email":
+                return userRepository.existsByEmail(value);
+            default:
+                throw new IllegalArgumentException("지원하지 않는 타입입니다: " + type);
+        }
+    }
+
+    /**
+     * 6. 사용자 존재 여부 확인 (다른 서비스용)
+     */
+    @Transactional(readOnly = true)
+    public boolean checkUserExists(Long userId) {
+        return userRepository.findById(userId)
+                .map(user -> !user.getIsDeleted())
+                .orElse(false);
+    }
+
+    /**
+     * 7. 프로필 수정용 상세 정보 조회
+     */
+    @Transactional(readOnly = true)
+    public UserDTO getProfileForEdit(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        if (user.getIsDeleted()) {
+            throw new UserNotFoundException("탈퇴한 사용자입니다.");
+        }
+
+        return userMapper.toUserDTO(user);
     }
 }

--- a/user-service/src/main/java/com/momnect/userservice/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/momnect/userservice/config/SecurityConfig.java
@@ -1,8 +1,9 @@
 package com.momnect.userservice.config;
 
-import com.momnect.userservice.security.HeaderAuthenticationFilter;
+import com.momnect.userservice.security.CookieAuthenticationFilter;
 import com.momnect.userservice.security.RestAccessDeniedHandler;
 import com.momnect.userservice.security.RestAuthenticationEntryPoint;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,6 +18,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+/**
+ * Spring Security 설정
+ * HttpOnly 쿠키 기반 JWT 인증 적용
+ */
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
@@ -25,6 +30,7 @@ public class SecurityConfig {
 
     private final RestAccessDeniedHandler restAccessDeniedHandler;
     private final RestAuthenticationEntryPoint restAuthenticationEntryPoint;
+    private final CookieAuthenticationFilter cookieAuthenticationFilter; // 🆕 변경!
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -45,16 +51,11 @@ public class SecurityConfig {
                                 .anyRequest()
                                 .authenticated()
                 )
-                .addFilterBefore(headerAuthenticationFilter(),
+                .addFilterBefore(cookieAuthenticationFilter, // 🆕 변경!
                         UsernamePasswordAuthenticationFilter.class)
         ;
 
         return http.build();
-    }
-
-    @Bean
-    public HeaderAuthenticationFilter headerAuthenticationFilter() {
-        return new HeaderAuthenticationFilter();
     }
 
     @Bean

--- a/user-service/src/main/java/com/momnect/userservice/exception/DuplicateUserException.java
+++ b/user-service/src/main/java/com/momnect/userservice/exception/DuplicateUserException.java
@@ -1,0 +1,7 @@
+package com.momnect.userservice.exception;
+
+public class DuplicateUserException extends RuntimeException {
+    public DuplicateUserException(String message) {
+        super(message);
+    }
+}

--- a/user-service/src/main/java/com/momnect/userservice/exception/UserNotFoundException.java
+++ b/user-service/src/main/java/com/momnect/userservice/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.momnect.userservice.exception;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/user-service/src/main/java/com/momnect/userservice/jwt/JwtTokenProvider.java
+++ b/user-service/src/main/java/com/momnect/userservice/jwt/JwtTokenProvider.java
@@ -32,59 +32,133 @@ public class JwtTokenProvider {
         secretKey = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    // AccessToken 생성
+    /**
+     * 토큰 유효성 검증
+     *
+     * @param token 검증할 JWT 토큰
+     * @return 토큰이 유효하면 true, 유효하지 않으면 false
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    /**
+     * 토큰에서 사용자 ID 추출
+     *
+     * @param token JWT 토큰
+     * @return 토큰에 포함된 사용자 ID
+     * @throws RuntimeException 토큰이 유효하지 않은 경우
+     */
+    public Long getUserIdFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return claims.get("userId", Long.class);
+    }
+
+    /**
+     * 토큰에서 사용자 역할 추출
+     *
+     * @param token JWT 토큰
+     * @return 토큰에 포함된 사용자 역할 (USER 등)
+     * @throws RuntimeException 토큰이 유효하지 않은 경우
+     */
+    public String getRoleFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return claims.get("role", String.class);
+    }
+
+    /**
+     * Access Token 생성
+     *
+     * @param user 토큰을 생성할 사용자 엔티티
+     * @return 생성된 Access Token 문자열
+     */
     public String createAccessToken(User user) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + expiration);
 
         return Jwts.builder()
-                .setSubject(user.getLoginId())       // username(sub)으로 loginId 사용
+                .subject(user.getLoginId())  // setSubject → subject)
                 .claim("userId", user.getId())
                 .claim("role", user.getRole())
-                .setIssuedAt(now)
-                .setExpiration(expiryDate)
-                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .claim("name", user.getName())
+                .claim("oauthProvider", user.getOauthProvider())
+                .issuedAt(now)  // (setIssuedAt → issuedAt)
+                .expiration(expiryDate)  //(setExpiration → expiration)
+                .signWith(secretKey)  // (signWith(algorithm, key) → signWith(key))
                 .compact();
     }
 
-    // RefreshToken 생성
+    /**
+     * Refresh Token 생성
+     *
+     * @param user 토큰을 생성할 사용자 엔티티
+     * @return 생성된 Refresh Token 문자열
+     */
     public String createRefreshToken(User user) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + refreshExpiration);
 
         return Jwts.builder()
-                .setSubject(user.getLoginId())
+                .subject(user.getLoginId())
                 .claim("userId", user.getId())
                 .claim("role", user.getRole())
-                .setIssuedAt(now)
-                .setExpiration(expiryDate)
-                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(secretKey)
                 .compact();
     }
 
-    // AccessToken 재발급 (RefreshToken 검증 후 사용)
+    /**
+     * Refresh Token을 이용한 Access Token 재발급
+     *
+     * @param refreshToken 유효한 Refresh Token
+     * @return 새로 생성된 Access Token
+     * @throws RuntimeException Refresh Token이 유효하지 않은 경우
+     */
     public String reissueAccessToken(String refreshToken) {
         try {
             Claims claims = Jwts.parser()
-                    .setSigningKey(secretKey)
+                    .verifyWith(secretKey)
                     .build()
-                    .parseClaimsJws(refreshToken)
-                    .getBody();
+                    .parseSignedClaims(refreshToken)
+                    .getPayload();
 
             String loginId = claims.getSubject();
             Long userId = claims.get("userId", Long.class);
             String role = claims.get("role", String.class);
+            String name = claims.get("name", String.class);
+            String oauthProvider = claims.get("oauthProvider", String.class);
 
             Date now = new Date();
             Date expiryDate = new Date(now.getTime() + expiration);
 
             return Jwts.builder()
-                    .setSubject(loginId)
+                    .subject(loginId)
                     .claim("userId", userId)
                     .claim("role", role)
-                    .setIssuedAt(now)
-                    .setExpiration(expiryDate)
-                    .signWith(SignatureAlgorithm.HS256, secretKey)
+                    .claim("name", name)
+                    .claim("oauthProvider", oauthProvider)
+                    .issuedAt(now)
+                    .expiration(expiryDate)
+                    .signWith(secretKey)
                     .compact();
 
         } catch (JwtException | IllegalArgumentException e) {

--- a/user-service/src/main/java/com/momnect/userservice/security/CookieAuthenticationFilter.java
+++ b/user-service/src/main/java/com/momnect/userservice/security/CookieAuthenticationFilter.java
@@ -1,0 +1,95 @@
+package com.momnect.userservice.security;
+
+import com.momnect.userservice.jwt.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * 쿠키 기반 JWT 인증 필터
+ * UsernamePasswordAuthenticationToken 사용
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class CookieAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        // 1. 헤더 방식 우선 확인 (Gateway에서 온 요청)
+        String userId = request.getHeader("X-User-Id");
+        String role = request.getHeader("X-User-Role");
+
+        if (userId != null && role != null) {
+            log.debug("[CookieAuthenticationFilter] Header auth - userId: {}, role: {}", userId, role);
+            setAuthentication(userId, role);
+        } else {
+            // 2. 쿠키 방식 확인 (직접 접근)
+            String accessToken = extractTokenFromCookie(request, "accessToken");
+
+            if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
+                Long userIdFromToken = jwtTokenProvider.getUserIdFromToken(accessToken);
+                String roleFromToken = jwtTokenProvider.getRoleFromToken(accessToken);
+
+                log.debug("[CookieAuthenticationFilter] Cookie auth - userId: {}, role: {}",
+                        userIdFromToken, roleFromToken);
+
+                // 다른 부분에서 사용할 수 있도록 request에 추가
+                request.setAttribute("X-User-Id", userIdFromToken.toString());
+                request.setAttribute("X-User-Role", roleFromToken);
+
+                setAuthentication(userIdFromToken.toString(), roleFromToken);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * 쿠키에서 토큰 추출
+     */
+    private String extractTokenFromCookie(@NonNull HttpServletRequest request, @NonNull String cookieName) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookieName.equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Spring Security 인증 설정
+     */
+    private void setAuthentication(String userId, String role) {
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(
+                        userId,
+                        null,
+                        List.of(new SimpleGrantedAuthority("ROLE_" + role))
+                );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}


### PR DESCRIPTION
**설명**: 
- 13개 API 구현 (인증/사용자관리/계정관리/서비스연동)
  - 회원가입, 로그인, 로그아웃, 프로필 수정, 프로필 수정용 조회
  - 비밀번호 변경, 중복 확인, 마이페이지, 타 사용자 프로필 조회
  - 회원탈퇴, 토큰 재발급, 사용자 존재 여부 확인
- HttpOnly 쿠키 기반 JWT 인증 보안 강화
- 회원 탈퇴 시 소프트 삭제 (탈퇴 사용자 로그인 차단)
- BCrypt 비밀번호 암호화
- UserMapper로 DTO 변환 통합 관리
- 로컬 DB 개발 환경 구축