### PR TITLE
fix: mongoDB에 메시지 저장 시 메시지를 보낸 유저의 아이디와 이름도 저장되게끔 수정

### DIFF
--- a/chat-service/src/main/java/com/momnect/chatservice/command/controller/ChatMessageController.java
+++ b/chat-service/src/main/java/com/momnect/chatservice/command/controller/ChatMessageController.java
@@ -7,11 +7,12 @@ import com.momnect.chatservice.command.dto.message.ChatMessageSendRequest;
 import com.momnect.chatservice.command.dto.message.UnreadCountResponse;
 import com.momnect.chatservice.command.service.ChatMessageService;
 import com.momnect.chatservice.command.service.ChatUnreadService;
+import com.momnect.chatservice.common.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import jakarta.validation.Valid;
 import java.util.List;
 
 @RestController
@@ -20,49 +21,52 @@ import java.util.List;
 public class ChatMessageController {
 
     private final ChatMessageService chatMessageService;
-    private final ChatUnreadService ChatUnreadService;
+    private final ChatUnreadService chatUnreadService;
 
     /** 메시지 전송 */
     @PostMapping
-    public ResponseEntity<ChatMessageResponse> send(
+    public ResponseEntity<ApiResponse<ChatMessageResponse>> send(
             @PathVariable Long roomId,
             @Valid @RequestBody ChatMessageSendRequest req
     ) {
-        return ResponseEntity.ok(chatMessageService.send(roomId, req));
+        ChatMessageResponse sent = chatMessageService.send(roomId, req);
+        return ResponseEntity.ok(ApiResponse.success(sent));
     }
 
     /** 메시지 조회 (최신순 페이지네이션) */
     @GetMapping
-    public ResponseEntity<PageResponse<ChatMessageResponse>> list(
+    public ResponseEntity<ApiResponse<PageResponse<ChatMessageResponse>>> list(
             @PathVariable Long roomId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size
     ) {
         List<ChatMessageResponse> content = chatMessageService.getMessages(roomId, page, size);
-        return ResponseEntity.ok(PageResponse.<ChatMessageResponse>builder()
+        PageResponse<ChatMessageResponse> body = PageResponse.<ChatMessageResponse>builder()
                 .content(content)
                 .page(page)
                 .size(size)
-                .total(-1) // 총 건수 필요 시 별도 계산
-                .build());
+                .total(-1) // 총 건수 필요시 서비스에서 계산해 채워도 됨
+                .build();
+        return ResponseEntity.ok(ApiResponse.success(body));
     }
 
     /** 읽음 처리 */
     @PostMapping("/read")
-    public ResponseEntity<Void> markRead(
+    public ResponseEntity<ApiResponse<Void>> markRead(
             @PathVariable Long roomId,
             @Valid @RequestBody ChatMessageMarkReadRequest req
     ) {
         chatMessageService.markAsRead(roomId, req);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     /** 나의 '해당 방' 안읽은 메시지 수 조회 */
     @GetMapping("/unread")
-    public ResponseEntity<UnreadCountResponse> getUnreadCount(
+    public ResponseEntity<ApiResponse<UnreadCountResponse>> getUnreadCount(
             @PathVariable Long roomId,
-            @RequestParam Long userId // 추후 SecurityContext로 대체 가능
+            @RequestParam Long userId // 추후 SecurityContext 대체 가능
     ) {
-        return ResponseEntity.ok(ChatUnreadService.getUnreadCount(roomId, userId));
+        UnreadCountResponse res = chatUnreadService.getUnreadCount(roomId, userId);
+        return ResponseEntity.ok(ApiResponse.success(res));
     }
 }

--- a/chat-service/src/main/java/com/momnect/chatservice/command/controller/ChatRoomController.java
+++ b/chat-service/src/main/java/com/momnect/chatservice/command/controller/ChatRoomController.java
@@ -5,11 +5,12 @@ import com.momnect.chatservice.command.dto.room.ChatRoomParticipantResponse;
 import com.momnect.chatservice.command.dto.room.ChatRoomResponse;
 import com.momnect.chatservice.command.dto.room.ChatRoomSummaryResponse;
 import com.momnect.chatservice.command.service.ChatRoomService;
+import com.momnect.chatservice.common.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import jakarta.validation.Valid;
 import java.util.List;
 
 @RestController
@@ -21,25 +22,22 @@ public class ChatRoomController {
 
     /** 방 생성 (이미 있으면 기존 방 반환) */
     @PostMapping
-    public ResponseEntity<ChatRoomResponse> create(@Valid @RequestBody ChatRoomCreateRequest req) {
-        return ResponseEntity.ok(chatRoomService.createRoom(req));
+    public ResponseEntity<ApiResponse<ChatRoomResponse>> create(@Valid @RequestBody ChatRoomCreateRequest req) {
+        ChatRoomResponse room = chatRoomService.createRoom(req);
+        return ResponseEntity.ok(ApiResponse.success(room));
     }
 
     /** 내가 참여한 방 목록 (최근 메시지 기준) */
     @GetMapping("/me/{userId}")
-    public ResponseEntity<List<ChatRoomSummaryResponse>> myRooms(@PathVariable Long userId) {
-        return ResponseEntity.ok(chatRoomService.listRoomsForUser(userId));
+    public ResponseEntity<ApiResponse<List<ChatRoomSummaryResponse>>> myRooms(@PathVariable Long userId) {
+        List<ChatRoomSummaryResponse> rooms = chatRoomService.listRoomsForUser(userId);
+        return ResponseEntity.ok(ApiResponse.success(rooms));
     }
 
     /** 방 참여자 목록 */
     @GetMapping("/{roomId}/participants")
-    public ResponseEntity<List<ChatRoomParticipantResponse>> participants(@PathVariable Long roomId) {
-        return ResponseEntity.ok(chatRoomService.getParticipants(roomId));
-    }
-
-    /** 방 단건 조회 */
-    @GetMapping("/{roomId}")
-    public ResponseEntity<ChatRoomResponse> getRoom(@PathVariable Long roomId) {
-        return ResponseEntity.ok(chatRoomService.getRoom(roomId));
+    public ResponseEntity<ApiResponse<List<ChatRoomParticipantResponse>>> participants(@PathVariable Long roomId) {
+        List<ChatRoomParticipantResponse> participants = chatRoomService.getParticipants(roomId);
+        return ResponseEntity.ok(ApiResponse.success(participants));
     }
 }

--- a/chat-service/src/main/java/com/momnect/chatservice/command/controller/ChatUnreadController.java
+++ b/chat-service/src/main/java/com/momnect/chatservice/command/controller/ChatUnreadController.java
@@ -1,8 +1,8 @@
-// com/momnect/chatservice/command/controller/ChatUnreadController.java
 package com.momnect.chatservice.command.controller;
 
 import com.momnect.chatservice.command.dto.message.RoomUnreadSummaryResponse;
 import com.momnect.chatservice.command.service.ChatUnreadService;
+import com.momnect.chatservice.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,9 +15,10 @@ public class ChatUnreadController {
 
     /** 내가 참여한 모든 방의 안읽은 메시지 합계 및 방별 수 */
     @GetMapping("/me/{userId}/unread")
-    public ResponseEntity<RoomUnreadSummaryResponse> getMyUnreadSummary(
+    public ResponseEntity<ApiResponse<RoomUnreadSummaryResponse>> getMyUnreadSummary(
             @PathVariable Long userId
     ) {
-        return ResponseEntity.ok(chatUnreadService.getMyUnreadSummary(userId));
+        RoomUnreadSummaryResponse summary = chatUnreadService.getMyUnreadSummary(userId);
+        return ResponseEntity.ok(ApiResponse.success(summary));
     }
 }

--- a/chat-service/src/main/java/com/momnect/chatservice/command/controller/WebSocketMessageController.java
+++ b/chat-service/src/main/java/com/momnect/chatservice/command/controller/WebSocketMessageController.java
@@ -21,8 +21,14 @@ public class WebSocketMessageController {
     @MessageMapping("/chat.send")
     public void onSend(@Payload WsSendMessage payload) {
         // 1) 영속화 + 응답 변환 (REST와 동일 로직 재사용)
-        var saved = chatMessageService.send(payload.getRoomId(),
-                new ChatMessageSendRequest(payload.getSenderId(), payload.getMessage()));
+        var saved = chatMessageService.send(
+                payload.getRoomId(),
+                ChatMessageSendRequest.builder()
+                        .senderId(payload.getSenderId())
+                        .senderName(payload.getSenderName())
+                        .message(payload.getMessage())
+                        .build()
+        );
 
         // 2) 방 구독자에게 브로드캐스트 (구독 주소: /topic/rooms.{roomId})
         String roomTopic = "/topic/rooms." + payload.getRoomId();

--- a/chat-service/src/main/java/com/momnect/chatservice/command/dto/message/ChatMessageSendRequest.java
+++ b/chat-service/src/main/java/com/momnect/chatservice/command/dto/message/ChatMessageSendRequest.java
@@ -6,5 +6,7 @@ import lombok.*;
 @NoArgsConstructor @AllArgsConstructor @Builder
 public class ChatMessageSendRequest {
     private Long senderId;
+    private String senderName;
     private String message;
 }
+

--- a/chat-service/src/main/java/com/momnect/chatservice/command/dto/message/WsSendMessage.java
+++ b/chat-service/src/main/java/com/momnect/chatservice/command/dto/message/WsSendMessage.java
@@ -6,5 +6,6 @@ import lombok.*;
 public class WsSendMessage {
     private Long roomId;
     private Long senderId;
+    private String senderName;
     private String message;
 }

--- a/chat-service/src/main/java/com/momnect/chatservice/command/entity/ChatRoom.java
+++ b/chat-service/src/main/java/com/momnect/chatservice/command/entity/ChatRoom.java
@@ -18,7 +18,7 @@ public class ChatRoom {
     private Long id;
 
     // 상품 ID (외부 참조)
-    @Column(name = "product_it", nullable = false) // DB 오타 product_it
+    @Column(name = "product_id", nullable = false)
     private Long productId;
 
     // 구매자

--- a/chat-service/src/main/java/com/momnect/chatservice/command/mongo/ChatMessage.java
+++ b/chat-service/src/main/java/com/momnect/chatservice/command/mongo/ChatMessage.java
@@ -22,8 +22,8 @@ public class ChatMessage {
     @Field("chat_room_id")
     private Long chatRoomId;
 
-    @Field("sender_id")
-    private Long senderId;
+    @Field("sender_info")
+    private SenderInfo senderInfo;
 
     @Field("message")
     private String message;
@@ -34,3 +34,4 @@ public class ChatMessage {
     @Field("is_read")
     private boolean isRead;
 }
+

--- a/chat-service/src/main/java/com/momnect/chatservice/command/mongo/SenderInfo.java
+++ b/chat-service/src/main/java/com/momnect/chatservice/command/mongo/SenderInfo.java
@@ -1,0 +1,15 @@
+package com.momnect.chatservice.command.mongo;
+
+import lombok.*;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+// 발신자 정보 내장 클래스
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class SenderInfo {
+    @Field("user_id")
+    private Long userId;
+
+    @Field("username")
+    private String username;
+}

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -25,6 +25,13 @@ spring:
               - "*"
             allowCredentials: true
       routes:
+        # WebSocket 업그레이드 라우트 (웹소켓 전용)
+        - id: chat-ws
+          uri: lb:ws://CHAT-SERVICE
+          predicates:
+            - Path=/api/v1/chat-service/ws/**
+          filters:
+            - RewritePath=/api/v1/chat-service/ws/(?<segment>.*), /ws/${segment}
         - id: user-service-auth
           uri: lb://USER-SERVICE
           predicates:
@@ -61,11 +68,8 @@ spring:
             - Path=/api/v1/review-service/**
           filters:
             - RewritePath=/api/v1/review-service/(?<segment>.*), /$\{segment}
-        # WebSocket 라우트 추가
-        - id: chat-ws
-          uri: lb:ws://CHAT-SERVICE
-          predicates:
-            - Path=/ws/**
+
+
 eureka:
   client:
     register-with-eureka: true


### PR DESCRIPTION
- 게이트웨이 application.yml에 webSocket 라우트 최상단으로 이동
- ApiResponse에 맞게 controller 수정 및 테이블 컬럼명 오타 수정