### PR TITLE
feat: 자녀 관리 API 구현

### DIFF
--- a/user-service/src/main/java/com/momnect/userservice/command/controller/ChildController.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/controller/ChildController.java
@@ -1,0 +1,99 @@
+// controller/ChildController.java
+package com.momnect.userservice.command.controller;
+
+import com.momnect.userservice.command.dto.ChildDTO;
+import com.momnect.userservice.command.dto.CreateChildRequest;
+import com.momnect.userservice.command.dto.UpdateChildRequest;
+import com.momnect.userservice.command.service.ChildService;
+import com.momnect.userservice.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Validated
+@Tag(name = "Child API", description = "자녀 관리 기능을 제공합니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users/children")
+public class ChildController {
+
+    private final ChildService childService;
+
+    /**
+     * 자녀 등록
+     */
+    @Operation(summary = "자녀 등록", description = "새로운 자녀 정보를 등록합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<ChildDTO>> createChild(
+            @Valid @RequestBody CreateChildRequest request,
+            HttpServletRequest httpRequest) {
+
+        Long userId = getUserIdFromRequest(httpRequest);
+        ChildDTO child = childService.createChild(userId, request);
+        return ResponseEntity.ok(ApiResponse.success(child));
+    }
+
+    /**
+     * 자녀 목록 조회
+     */
+    @Operation(summary = "자녀 목록 조회", description = "등록된 자녀 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ChildDTO>>> getChildren(HttpServletRequest httpRequest) {
+        Long userId = getUserIdFromRequest(httpRequest);
+        List<ChildDTO> children = childService.getChildren(userId);
+        return ResponseEntity.ok(ApiResponse.success(children));
+    }
+
+    /**
+     * 자녀 정보 수정
+     */
+    @Operation(summary = "자녀 정보 수정", description = "등록된 자녀 정보를 수정합니다.")
+    @PutMapping("/{childId}")
+    public ResponseEntity<ApiResponse<ChildDTO>> updateChild(
+            @PathVariable Long childId,
+            @Valid @RequestBody UpdateChildRequest request,
+            HttpServletRequest httpRequest) {
+
+        Long userId = getUserIdFromRequest(httpRequest);
+        ChildDTO child = childService.updateChild(userId, childId, request);
+        return ResponseEntity.ok(ApiResponse.success(child));
+    }
+
+    /**
+     * 자녀 삭제
+     */
+    @Operation(summary = "자녀 정보 삭제", description = "등록된 자녀 정보를 삭제합니다.")
+    @DeleteMapping("/{childId}")
+    public ResponseEntity<ApiResponse<Void>> deleteChild(
+            @PathVariable Long childId,
+            HttpServletRequest httpRequest) {
+
+        Long userId = getUserIdFromRequest(httpRequest);
+        childService.deleteChild(userId, childId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    /**
+     * 요청에서 사용자 ID 추출
+     */
+    private Long getUserIdFromRequest(HttpServletRequest request) {
+        String userIdHeader = request.getHeader("X-User-Id");
+        if (userIdHeader != null) {
+            return Long.parseLong(userIdHeader);
+        }
+
+        Object userIdAttr = request.getAttribute("X-User-Id");
+        if (userIdAttr != null) {
+            return Long.parseLong(userIdAttr.toString());
+        }
+
+        throw new RuntimeException("사용자 인증 정보를 찾을 수 없습니다.");
+    }
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/dto/ChildDTO.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/dto/ChildDTO.java
@@ -1,0 +1,17 @@
+package com.momnect.userservice.command.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class ChildDTO {
+    private Long id;           // 자녀 ID
+    private Long userId;       // 부모 ID
+    private String nickname;   // 애칭
+    private LocalDate birthDate; // 생년월일
+    private Integer age;       // 만 나이 (자동 계산)
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/dto/CreateChildRequest.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/dto/CreateChildRequest.java
@@ -1,0 +1,22 @@
+package com.momnect.userservice.command.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+import java.time.LocalDate;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateChildRequest {
+
+    @NotBlank(message = "자녀 애칭을 입력해주세요")
+    @Size(max = 15, message = "애칭은 15자 이하로 입력해주세요")
+    private final String nickname;
+
+    @NotNull(message = "생년월일을 입력해주세요")
+    private final LocalDate birthDate;
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/dto/UpdateChildRequest.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/dto/UpdateChildRequest.java
@@ -1,0 +1,17 @@
+package com.momnect.userservice.command.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@RequiredArgsConstructor
+public class UpdateChildRequest {
+
+    @Size(max = 15, message = "애칭은 15자 이하로 입력해주세요")
+    private final String nickname;  // null 가능 (부분 업데이트)
+
+    private final LocalDate birthDate;  // null 가능 (부분 업데이트)
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/entity/Child.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/entity/Child.java
@@ -1,0 +1,29 @@
+package com.momnect.userservice.command.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "tbl_children")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Child {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 자녀의 고유 ID (PK)
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId; // 부모(사용자)의 ID
+
+    @Column(name = "nickname", length = 15)
+    private String nickname; // 자녀 애칭
+
+    @Column(name = "birth_date", nullable = false)
+    private LocalDate birthDate; // 자녀 생년월일
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/repository/ChildRepository.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/repository/ChildRepository.java
@@ -1,0 +1,24 @@
+package com.momnect.userservice.command.repository;
+
+import com.momnect.userservice.command.entity.Child;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ChildRepository extends JpaRepository<Child, Long> {
+
+    // 특정 사용자의 자녀 목록 조회 (등록 순서대로)
+    List<Child> findByUserIdOrderByIdAsc(Long userId);
+
+    // 특정 사용자의 특정 자녀 조회 (본인 자녀만 접근 가능)
+    Optional<Child> findByIdAndUserId(Long id, Long userId);
+
+    // 특정 사용자의 자녀 수 조회 (최대 2명 제한 체크용)
+    int countByUserId(Long userId);
+
+    // 특정 사용자의 자녀 존재 여부 확인
+    boolean existsByUserId(Long userId);
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/service/ChildService.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/service/ChildService.java
@@ -1,0 +1,194 @@
+package com.momnect.userservice.command.service;
+
+import com.momnect.userservice.command.dto.ChildDTO;
+import com.momnect.userservice.command.dto.CreateChildRequest;
+import com.momnect.userservice.command.dto.UpdateChildRequest;
+import com.momnect.userservice.command.entity.Child;
+import com.momnect.userservice.command.repository.ChildRepository;
+import com.momnect.userservice.exception.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class ChildService {
+
+    private final ChildRepository childRepository;
+    private static final int MAX_CHILDREN = 2; // 최대 자녀 수 제한
+
+    /**
+     * 자녀 등록
+     */
+    public ChildDTO createChild(Long userId, CreateChildRequest request) {
+        log.info("자녀 등록 시작: userId={}, nickname={}", userId, request.getNickname());
+
+        // 입력값 검증
+        validateCreateChildRequest(request);
+
+        // 자녀 수 제한 확인
+        validateChildrenLimit(userId);
+
+        // 자녀 생성
+        Child child = buildChildFromRequest(userId, request);
+        Child savedChild = childRepository.save(child);
+
+        log.info("자녀 등록 완료: childId={}", savedChild.getId());
+        return toChildDTO(savedChild);
+    }
+
+    /**
+     * 자녀 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<ChildDTO> getChildren(Long userId) {
+        log.info("자녀 목록 조회: userId={}", userId);
+
+        List<Child> children = childRepository.findByUserIdOrderByIdAsc(userId);
+
+        return children.stream()
+                .map(this::toChildDTO)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 자녀 정보 수정
+     */
+    public ChildDTO updateChild(Long userId, Long childId, UpdateChildRequest request) {
+        log.info("자녀 수정 시작: userId={}, childId={}", userId, childId);
+
+        // 자녀 조회 (본인 자녀만)
+        Child child = childRepository.findByIdAndUserId(childId, userId)
+                .orElseThrow(() -> new UserNotFoundException("자녀 정보를 찾을 수 없습니다"));
+
+        // 입력값 검증
+        validateUpdateChildRequest(request);
+
+        // 자녀 정보 업데이트
+        updateChildInfo(child, request);
+        Child savedChild = childRepository.save(child);
+
+        log.info("자녀 수정 완료: childId={}", childId);
+        return toChildDTO(savedChild);
+    }
+
+    /**
+     * 자녀 삭제
+     */
+    public void deleteChild(Long userId, Long childId) {
+        log.info("자녀 삭제 시작: userId={}, childId={}", userId, childId);
+
+        // 자녀 조회 (본인 자녀만)
+        Child child = childRepository.findByIdAndUserId(childId, userId)
+                .orElseThrow(() -> new UserNotFoundException("자녀 정보를 찾을 수 없습니다"));
+
+        childRepository.delete(child);
+
+        log.info("자녀 삭제 완료: childId={}", childId);
+    }
+
+    /**
+     * 자녀 등록 요청 검증
+     */
+    private void validateCreateChildRequest(CreateChildRequest request) {
+        if (request.getNickname() == null || request.getNickname().trim().isEmpty()) {
+            throw new IllegalArgumentException("자녀 애칭을 입력해주세요");
+        }
+
+        if (request.getBirthDate() == null) {
+            throw new IllegalArgumentException("생년월일을 입력해주세요");
+        }
+
+        if (request.getBirthDate().isAfter(LocalDate.now())) {
+            throw new IllegalArgumentException("생년월일은 현재 날짜 이전이어야 합니다");
+        }
+
+        // 8세 미만만 등록 가능 (영유아 대상 서비스)
+        if (request.getBirthDate().isBefore(LocalDate.now().minusYears(8))) {
+            throw new IllegalArgumentException("8세 이상은 등록할 수 없습니다 (영유아 대상 서비스)");
+        }
+    }
+
+    /**
+     * 자녀 수정 요청 검증
+     */
+    private void validateUpdateChildRequest(UpdateChildRequest request) {
+        if (request.getNickname() != null && request.getNickname().trim().isEmpty()) {
+            throw new IllegalArgumentException("자녀 애칭은 비워둘 수 없습니다");
+        }
+
+        if (request.getBirthDate() != null) {
+            if (request.getBirthDate().isAfter(LocalDate.now())) {
+                throw new IllegalArgumentException("생년월일은 현재 날짜 이전이어야 합니다");
+            }
+
+            if (request.getBirthDate().isBefore(LocalDate.now().minusYears(8))) {
+                throw new IllegalArgumentException("8세 이상은 등록할 수 없습니다 (영유아 대상 서비스)");
+            }
+        }
+    }
+
+    /**
+     * 자녀 수 제한 확인
+     */
+    private void validateChildrenLimit(Long userId) {
+        int currentChildrenCount = childRepository.countByUserId(userId);
+        if (currentChildrenCount >= MAX_CHILDREN) {
+            throw new IllegalArgumentException("최대 " + MAX_CHILDREN + "명까지만 등록 가능합니다");
+        }
+    }
+
+    /**
+     * CreateChildRequest에서 Child 엔티티 생성
+     */
+    private Child buildChildFromRequest(Long userId, CreateChildRequest request) {
+        return Child.builder()
+                .userId(userId)
+                .nickname(request.getNickname().trim())
+                .birthDate(request.getBirthDate())
+                .build();
+    }
+
+    /**
+     * 자녀 정보 업데이트
+     */
+    private void updateChildInfo(Child child, UpdateChildRequest request) {
+        if (request.getNickname() != null) {
+            child.setNickname(request.getNickname().trim());
+        }
+        if (request.getBirthDate() != null) {
+            child.setBirthDate(request.getBirthDate());
+        }
+    }
+
+    /**
+     * Child 엔티티를 ChildDTO로 변환
+     */
+    private ChildDTO toChildDTO(Child child) {
+        int age = calculateAge(child.getBirthDate());
+
+        return ChildDTO.builder()
+                .id(child.getId())
+                .userId(child.getUserId())
+                .nickname(child.getNickname())
+                .birthDate(child.getBirthDate())
+                .age(age)
+                .build();
+    }
+
+    /**
+     * 나이 계산 (년 단위)
+     */
+    private int calculateAge(LocalDate birthDate) {
+        if (birthDate == null) return 0;
+        return Period.between(birthDate, LocalDate.now()).getYears();
+    }
+}


### PR DESCRIPTION
- Child 엔티티 생성 (id, userId, nickname, birthDate)
- ChildRepository 인터페이스 구현
- ChildService CRUD 로직 구현 (최대 2명, 8세 미만 제한)
- ChildController REST API 엔드포인트 구현
- 관련 DTO 생성 (ChildDTO, CreateChildRequest, UpdateChildRequest)
- 만 나이 자동 계산 기능
- 본인 자녀만 접근 가능