### PR TITLE
feat: 계정 복구 API 구현

### DIFF
--- a/user-service/src/main/java/com/momnect/userservice/command/controller/AuthController.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/controller/AuthController.java
@@ -1,8 +1,6 @@
 package com.momnect.userservice.command.controller;
 
-import com.momnect.userservice.command.dto.AuthResponseDTO;
-import com.momnect.userservice.command.dto.LoginRequest;
-import com.momnect.userservice.command.dto.SignupRequest;
+import com.momnect.userservice.command.dto.*;
 import com.momnect.userservice.command.service.AuthService;
 import com.momnect.userservice.common.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -85,6 +83,28 @@ public class AuthController {
                 .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
                 .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
                 .body(ApiResponse.success(null));
+    }
+
+    /**
+     * 통합 계정 확인 (아이디 찾기 / 비밀번호 재설정)
+     */
+    @PostMapping("/verify-account")
+    public ResponseEntity<ApiResponse<VerifyAccountResponse>> verifyAccount(
+            @Valid @RequestBody VerifyAccountRequest request) {
+
+        VerifyAccountResponse response = authService.verifyAccount(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+        /**
+         * 비밀번호 재설정
+         */
+    @PutMapping("/reset-password")
+    public ResponseEntity<ApiResponse<String>> resetPassword(
+            @Valid @RequestBody ResetPasswordRequest request) {
+
+        authService.resetPassword(request);
+        return ResponseEntity.ok(ApiResponse.success("비밀번호가 성공적으로 변경되었습니다"));
     }
 
     /**

--- a/user-service/src/main/java/com/momnect/userservice/command/dto/ResetPasswordRequest.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/dto/ResetPasswordRequest.java
@@ -1,0 +1,28 @@
+package com.momnect.userservice.command.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ResetPasswordRequest {
+
+    @NotBlank(message = "재설정 토큰을 입력해주세요")
+    private final String resetToken;
+
+    @NotBlank(message = "새 비밀번호를 입력해주세요")
+    @Size(min = 8, max = 16, message = "비밀번호는 8-16자리로 입력해주세요")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*(),.?\"{}|<>]).{8,16}$",
+            message = "비밀번호는 영문자, 숫자, 특수문자를 포함해야 합니다")
+    private final String newPassword;
+
+    @NotBlank(message = "비밀번호 확인을 입력해주세요")
+    private final String newPasswordConfirm;
+
+    public boolean isPasswordMatched() {
+        return newPassword != null && newPassword.equals(newPasswordConfirm);
+    }
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/dto/VerifyAccountRequest.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/dto/VerifyAccountRequest.java
@@ -1,0 +1,25 @@
+package com.momnect.userservice.command.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class VerifyAccountRequest {
+
+    @NotNull(message = "요청 타입은 필수입니다")
+    private final String type; // "FIND_ID", "RESET_PASSWORD"
+
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    private final String email;
+
+    // 아이디 찾기용 (type=FIND_ID일 때 필요)
+    private final String name;
+
+    // 비밀번호 찾기용 (type=RESET_PASSWORD일 때 필요)
+    private final String loginId;
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/dto/VerifyAccountResponse.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/dto/VerifyAccountResponse.java
@@ -1,0 +1,38 @@
+package com.momnect.userservice.command.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+public class VerifyAccountResponse {
+
+    private String type;
+    private boolean success;
+    private String message;
+
+    // 아이디 찾기 결과
+    private String loginId;
+
+    // 비밀번호 재설정 토큰
+    private String resetToken;
+
+    public static VerifyAccountResponse findIdSuccess(String maskedLoginId) {
+        return VerifyAccountResponse.builder()
+                .type("FIND_ID")
+                .success(true)
+                .message("계정을 찾았습니다")
+                .loginId(maskedLoginId)
+                .build();
+    }
+
+    public static VerifyAccountResponse resetPasswordSuccess(String resetToken) {
+        return VerifyAccountResponse.builder()
+                .type("RESET_PASSWORD")
+                .success(true)
+                .message("계정이 확인되었습니다")
+                .resetToken(resetToken)
+                .build();
+    }
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/service/AuthService.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/service/AuthService.java
@@ -6,6 +6,7 @@ import com.momnect.userservice.command.repository.UserRepository;
 import com.momnect.userservice.exception.UserNotFoundException;
 import com.momnect.userservice.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +15,7 @@ import com.momnect.userservice.command.mapper.UserMapper;
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class AuthService {
 
     private final UserRepository userRepository;
@@ -165,5 +167,104 @@ public class AuthService {
                 .createdBy(0L) // 임시값, 저장 후 실제 ID로 업데이트
                 .updatedBy(0L) // 임시값, 저장 후 실제 ID로 업데이트
                 .build();
+    }
+
+    /**
+     * 통합 계정 확인 (아이디 찾기 / 비밀번호 재설정)
+     */
+    public VerifyAccountResponse verifyAccount(VerifyAccountRequest request) {
+        log.info("계정 확인 요청: type={}, email={}", request.getType(), request.getEmail());
+
+        // 입력값 검증
+        validateVerifyRequest(request);
+
+        if ("FIND_ID".equals(request.getType())) {
+            return handleFindId(request);
+        } else if ("RESET_PASSWORD".equals(request.getType())) {
+            return handleResetPassword(request);
+        } else {
+            throw new IllegalArgumentException("지원하지 않는 요청 타입입니다: " + request.getType());
+        }
+    }
+
+    /**
+     * 비밀번호 재설정
+     */
+    public void resetPassword(ResetPasswordRequest request) {
+        log.info("비밀번호 재설정 요청");
+
+        // 비밀번호 일치 확인
+        if (!request.isPasswordMatched()) {
+            throw new IllegalArgumentException("새 비밀번호가 일치하지 않습니다");
+        }
+
+        // 토큰 검증 및 사용자 ID 추출
+        Long userId = jwtTokenProvider.getUserIdFromPasswordResetToken(request.getResetToken());
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다"));
+
+        if (user.getIsDeleted()) {
+            throw new RuntimeException("탈퇴한 사용자입니다");
+        }
+
+        // 비밀번호 변경
+        user.setPassword(passwordEncoder.encode(request.getNewPassword()));
+        user.setUpdatedBy(userId);
+        userRepository.save(user);
+
+        log.info("비밀번호 재설정 완료: userId={}", userId);
+    }
+
+    /**
+     * 아이디 찾기 처리
+     */
+    private VerifyAccountResponse handleFindId(VerifyAccountRequest request) {
+        // 이름과 이메일로 사용자 찾기
+        User user = userRepository.findByEmail(request.getEmail())
+                .filter(u -> !u.getIsDeleted())
+                .filter(u -> request.getName().equals(u.getName()))
+                .orElseThrow(() -> new RuntimeException("일치하는 사용자 정보를 찾을 수 없습니다"));
+
+        log.info("아이디 찾기 완료: userId={}", user.getId());
+        return VerifyAccountResponse.findIdSuccess(user.getLoginId());
+    }
+
+    /**
+     * 비밀번호 재설정 처리
+     */
+    private VerifyAccountResponse handleResetPassword(VerifyAccountRequest request) {
+        // 아이디와 이메일로 사용자 찾기
+        User user = userRepository.findByLoginId(request.getLoginId())
+                .filter(u -> !u.getIsDeleted())
+                .filter(u -> request.getEmail().equals(u.getEmail()))
+                .orElseThrow(() -> new RuntimeException("일치하는 사용자 정보를 찾을 수 없습니다"));
+
+        // 소셜 로그인 사용자는 비밀번호 재설정 불가
+        if (!"LOCAL".equals(user.getOauthProvider())) {
+            throw new RuntimeException("소셜 로그인 사용자는 비밀번호를 재설정할 수 없습니다");
+        }
+
+        // 재설정 토큰 생성
+        String resetToken = jwtTokenProvider.createPasswordResetToken(user.getId());
+
+        log.info("비밀번호 재설정 토큰 생성 완료: userId={}", user.getId());
+        return VerifyAccountResponse.resetPasswordSuccess(resetToken);
+    }
+
+    /**
+     * 계정 확인 요청 검증
+     */
+    private void validateVerifyRequest(VerifyAccountRequest request) {
+        if ("FIND_ID".equals(request.getType())) {
+            if (request.getName() == null || request.getName().trim().isEmpty()) {
+                throw new IllegalArgumentException("아이디 찾기 시 이름은 필수입니다");
+            }
+        } else if ("RESET_PASSWORD".equals(request.getType())) {
+            if (request.getLoginId() == null || request.getLoginId().trim().isEmpty()) {
+                throw new IllegalArgumentException("비밀번호 재설정 시 아이디는 필수입니다");
+            }
+        }
     }
 }

--- a/user-service/src/main/java/com/momnect/userservice/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/momnect/userservice/config/SecurityConfig.java
@@ -43,10 +43,10 @@ public class SecurityConfig {
                                         .authenticationEntryPoint(restAuthenticationEntryPoint)
                 )
                 .authorizeHttpRequests(auth ->
-                        auth.requestMatchers(HttpMethod.POST, "/auth/signup", "/auth/login")
-                                .permitAll()
-                                .requestMatchers(HttpMethod.GET, "/users/check")
-                                .permitAll()
+                        auth.requestMatchers(HttpMethod.POST, "/auth/signup", "/auth/login").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/users/check").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/auth/verify-account").permitAll()
+                                .requestMatchers(HttpMethod.PUT, "/auth/reset-password").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/swagger-ui/**", "/v3/api-docs/**",
                                         "/swagger-resources/**")
                                 .permitAll()


### PR DESCRIPTION
- 통합 계정 확인 API (아이디 찾기/비밀번호 재설정)
- JWT 기반 비밀번호 재설정 토큰 시스템 (30분 만료)
- 아이디 찾기: 이름+이메일로 아이디 반환
- 비밀번호 재설정: 아이디+이메일로 토큰 발급 후 새 비밀번호 설정
- 소셜 로그인 사용자 비밀번호 재설정 차단
- Security 설정 업데이트 (익명 접근 허용)