### PR TITLE
feat: SecurityConfig 보안 설정에 공개 api 경로 추가

### DIFF
--- a/user-service/src/main/java/com/momnect/userservice/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/momnect/userservice/config/SecurityConfig.java
@@ -43,18 +43,16 @@ public class SecurityConfig {
                                         .authenticationEntryPoint(restAuthenticationEntryPoint)
                 )
                 .authorizeHttpRequests(auth ->
-                        auth.requestMatchers(HttpMethod.POST, "/auth/signup", "/auth/login").permitAll()
-                                .requestMatchers(HttpMethod.GET, "/users/check").permitAll()
-                                .requestMatchers(HttpMethod.POST, "/auth/verify-account").permitAll()
+                        auth.requestMatchers(HttpMethod.POST, "/auth/signup", "/auth/login", "/auth/verify-account").permitAll()
                                 .requestMatchers(HttpMethod.PUT, "/auth/reset-password").permitAll()
-                                .requestMatchers(HttpMethod.GET, "/swagger-ui/**", "/v3/api-docs/**",
-                                        "/swagger-resources/**")
-                                .permitAll()
-                                .anyRequest()
-                                .authenticated()
+                                .requestMatchers(HttpMethod.GET, "/users/check").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/users/{userId}").permitAll() // 타사용자 기본 정보
+                                .requestMatchers(HttpMethod.GET, "/users/{userId}/exists").permitAll() // 사용자 존재 여부 확인
+                                .requestMatchers(HttpMethod.GET, "/users/{userId}/basic").permitAll() // 헤더용 기본 정보
+                                .requestMatchers(HttpMethod.GET, "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**").permitAll()
+                                .anyRequest().authenticated()
                 )
-                .addFilterBefore(cookieAuthenticationFilter,
-                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(cookieAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
         ;
 
         return http.build();


### PR DESCRIPTION
.requestMatchers(HttpMethod.GET, "/users/{userId}").permitAll() // 타사용자 기본 정보
                                .requestMatchers(HttpMethod.GET, "/users/{userId}/exists").permitAll() // 사용자 존재 여부 확인
                                .requestMatchers(HttpMethod.GET, "/users/{userId}/basic").permitAll() // 헤더용 기본 정보 추가
- 이 API들은 외부 서비스나 프론트엔드에서 사용자의 공개 정보를 조회하거나 존재 여부를 확인하는 용도이므로, 사용자 인증 절차를 거칠 필요가 없기 때문