### PR TITLE
마이페이지 대시보드 API(GET /me/dashboard)를 추가

### DIFF
--- a/user-service/src/main/java/com/momnect/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/momnect/userservice/UserServiceApplication.java
@@ -3,9 +3,11 @@ package com.momnect.userservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@EnableFeignClients(basePackages = "com.momnect.userservice.command.client")
 public class UserServiceApplication {
 
     public static void main(String[] args) {

--- a/user-service/src/main/java/com/momnect/userservice/command/client/ProductClient.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/client/ProductClient.java
@@ -1,16 +1,28 @@
 package com.momnect.userservice.command.client;
 
+import com.momnect.userservice.command.dto.ProductSummaryDTO;
+import com.momnect.userservice.command.dto.TransactionSummaryDTO;
+import com.momnect.userservice.common.ApiResponse;
 import com.momnect.userservice.config.FeignClientConfig;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
-// **** 예시 파일입니다. 추후 수정해서 사용
-// gateway 통해서 접근
+import java.util.List;
+
 @FeignClient(name = "product-service", url = "http://localhost:8000/api/v1/product-service", configuration = FeignClientConfig.class)
 public interface ProductClient {
 
-//    // 지역 정보 요청
-//    @GetMapping("/products/areas")
-//    AreaDTO getAreas(@RequestBody AreaRequest request);
+    // 거래 현황 요약 정보
+    @GetMapping("/trades/me/summary")
+    ApiResponse<TransactionSummaryDTO> getMyTransactionSummary(@RequestHeader("X-User-Id") Long userId);
+
+    // 구매 상품 목록 조회
+    @GetMapping("/trades/me/purchases")
+    ApiResponse<List<ProductSummaryDTO>> getMyPurchases(@RequestHeader("X-User-Id") Long userId);
+
+    // 판매 상품 목록 조회
+    @GetMapping("/trades/me/sales")
+    ApiResponse<List<ProductSummaryDTO>> getMySales(@RequestHeader("X-User-Id") Long userId);
 }

--- a/user-service/src/main/java/com/momnect/userservice/command/controller/UserController.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.momnect.userservice.command.controller;
 
 import com.momnect.userservice.command.dto.*;
+import com.momnect.userservice.command.service.ChildService;
 import com.momnect.userservice.command.service.UserService;
 import com.momnect.userservice.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,12 +11,15 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
 public class UserController {
 
     private final UserService userService;
+    private final ChildService childService; // ChildService를 주입받도록 수정
 
     /**
      * 헤더용 기본 정보 (닉네임, 이미지만)
@@ -36,18 +40,33 @@ public class UserController {
     }
 
     /**
-     * 마이페이지 기본 정보 (닉네임, 이미지만) - 프론트엔드용
-     * 자녀정보는 자녀관리 API 완성 후 제거 예정
+     * 마이페이지 메인 대시보드 정보(통합, 읽기 전용)
      */
-    @Operation(summary = "마이페이지 기본 정보", description = "프로필 정보를 조회합니다.")
-    @GetMapping("/me")
-    public ResponseEntity<ApiResponse<PublicUserDTO>> getMyInfo(HttpServletRequest request) {
+    @Operation(summary = "마이페이지 대시보드 통합 정보", description = "프로필, 자녀정보, 거래 현황 등 대시보드에 필요한 모든 정보 조회")
+    @GetMapping("/me/dashboard")
+    public ResponseEntity<ApiResponse<MypageDTO>> getMypageDashboard(HttpServletRequest request) {
         Long userId = getUserIdFromRequest(request);
-        PublicUserDTO userInfo = userService.getPublicUserProfile(userId);
-        return ResponseEntity.ok(ApiResponse.success(userInfo));
 
-        // TODO: 자녀관리 API 완성 후 자녀 정보 추가
-        // TODO: 프론트엔드에서 자녀관리 API 별도 호출로 변경
+        // 1. 프로필 정보 조회
+        PublicUserDTO profileInfo = userService.getPublicUserProfile(userId);
+
+        // 2. 자녀 정보 목록 조회
+        List<ChildDTO> children = childService.getChildren(userId);
+
+        // 3. 거래 현황 조회 (상품 서비스 및 리뷰 서비스 연동)
+        // TODO: Feign Client를 통해 실제 거래 현황 데이터로 교체
+        TransactionSummaryDTO transactionSummary = new TransactionSummaryDTO(); // 임시 DTO 생성
+        transactionSummary.setTotalSalesCount(0);
+        transactionSummary.setPurchaseCount(0);
+        transactionSummary.setReviewCount(0);
+
+        MypageDTO dashboardInfo = MypageDTO.builder()
+                .profileInfo(profileInfo)
+                .childList(children)
+                .transactionSummary(transactionSummary)
+                .build();
+
+        return ResponseEntity.ok(ApiResponse.success(dashboardInfo));
     }
 
     /**

--- a/user-service/src/main/java/com/momnect/userservice/command/dto/MypageDTO.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/dto/MypageDTO.java
@@ -1,0 +1,15 @@
+package com.momnect.userservice.command.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MypageDTO {
+
+    private PublicUserDTO profileInfo;
+    private List<ChildDTO> childList;
+    private TransactionSummaryDTO transactionSummary;
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/dto/ProductSummaryDTO.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/dto/ProductSummaryDTO.java
@@ -1,0 +1,23 @@
+package com.momnect.userservice.command.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ProductSummaryDTO {
+
+    private Long id;
+    private String thumbnailUrl;        // 상품 이미지 썸네일
+    private Boolean isWishList;         // 찜하기
+    private int price;                  // 가격
+    private String emd;                 // 읍면동
+    private LocalDateTime createdAt;    // 생성일시
+    private String productStatus;       // 상품 상태
+    private String tradeStatus;         // 거래 상태
+    private Boolean isDeleted;          // 삭제 여부
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/dto/TransactionSummaryDTO.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/dto/TransactionSummaryDTO.java
@@ -1,0 +1,18 @@
+package com.momnect.userservice.command.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TransactionSummaryDTO {
+
+    private int totalSalesCount; // 총 판매 수
+    private int purchaseCount;   // 총 구매 수
+    private int reviewCount;     // 작성한 리뷰 개수
+}

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -24,6 +24,17 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  # 여기에 feign 설정을 추가
+  feign:
+    client:
+      config:
+        default:
+          connectTimeout: 5000
+          readTimeout: 5000
+      product-service:
+        url: http://localhost:8000/api/v1/product-service
+      review-service:
+        url: http://localhost:8000/api/v1/review-service
 
 # swagger
 springdoc:


### PR DESCRIPTION
- PublicUserDTO, ChildDTO, TransactionSummaryDTO 등 마이페이지 데이터 구조를 위한 DTO 3개 추가
- UserController에 마이페이지 API 엔드포인트를 구현하고, UserService에 Feign 클라이언트를 연동하여 상품 서비스의 거래 현황 데이터를 가져오도록 수정
- CookieAuthenticationFilter를 Authorization 헤더 기반으로 동작하도록 수정하여, 토큰 인증 로직 개선