### PR TITLE
feat: 기본 프로필 이미지 추가 및 사용자 프로필 로직 개선

### DIFF
--- a/user-service/src/main/java/com/momnect/userservice/command/client/FileClient.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/client/FileClient.java
@@ -1,0 +1,23 @@
+package com.momnect.userservice.command.client;
+
+import com.momnect.userservice.command.dto.file.ImageFileDTO;
+import com.momnect.userservice.common.ApiResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@FeignClient(name = "file-service", url = "http://dev.macacolabs.site:8008")
+public interface FileClient {
+
+    @PostMapping(value = "/files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    ApiResponse<List<ImageFileDTO>> uploadImage(@RequestPart("imageFiles") MultipartFile file);
+
+    @GetMapping("/files")
+    ApiResponse<List<ImageFileDTO>> getImagesByIds(@RequestParam("ids") String ids);
+
+    @DeleteMapping("/files/{id}")
+    ApiResponse<Void> deleteImage(@PathVariable("id") Long id);
+}

--- a/user-service/src/main/java/com/momnect/userservice/command/controller/UserController.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/controller/UserController.java
@@ -66,11 +66,7 @@ public class UserController {
         // 리뷰 서비스가 아직 없으므로 임시로 0 설정
         transactionSummary.setReviewCount(0);
 
-        MypageDTO dashboardInfo = MypageDTO.builder()
-                .profileInfo(profileInfo)
-                .childList(children)
-                .transactionSummary(transactionSummary)
-                .build();
+        MypageDTO dashboardInfo = userService.getMypageDashboard(userId);
 
         return ResponseEntity.ok(ApiResponse.success(dashboardInfo));
     }

--- a/user-service/src/main/java/com/momnect/userservice/command/dto/file/ImageFileDTO.java
+++ b/user-service/src/main/java/com/momnect/userservice/command/dto/file/ImageFileDTO.java
@@ -1,0 +1,20 @@
+package com.momnect.userservice.command.dto.file;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ImageFileDTO {
+
+    private Long id;
+    private String originalName;        // 원본 이미지 파일명
+    private String storedName;          // 파일 서버에 저장된 파일명
+    private String path;                // 파일이 저장된 경로
+    private Long size;                  // 파일 크기 (바이트)
+    private String extension;           // 파일 확장자 (예: jpg, png)
+    private Boolean isDeleted;          // 삭제 여부
+    private LocalDateTime createdAt;    // 생성 일시
+}

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -41,3 +41,7 @@ springdoc:
   packages-to-scan: com.momnect.userservice
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
+
+# 파일 서비스 URL 설정
+ftp:
+  file-server-url: http://dev.macacolabs.site:8008


### PR DESCRIPTION
- **UserController**: 비즈니스 로직을 중앙화하기 위해 `/me/dashboard` 엔드포인트를 `UserService` 호출 하나로 리팩토링.
- **UserService**:
    - 커스텀 이미지가 없는 사용자를 위해 기본 프로필 이미지 할당 로직 구현.
    - 동적으로 이미지 경로를 처리하도록 `FileClient` 및 `ftp.file-server-url` 추가.
    - 프론트엔드에서 빈 프로필 이미지 URL이 들어올 때 기본 이미지가 올바르게 설정되지 않던 버그 수정.
    - 향후 파일 서비스 연동을 위한 `FileClient`와 관련 DTO 생성.