### PR TITLE
fix: 회원가입/로그인 경로에 대한 Gateway 인증 예외 처리

### DIFF
--- a/gateway-service/src/main/java/com/momnect/gatewayservice/filter/JwtAuthenticationFilter.java
+++ b/gateway-service/src/main/java/com/momnect/gatewayservice/filter/JwtAuthenticationFilter.java
@@ -23,6 +23,15 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
      * */
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        String path = exchange.getRequest().getURI().getPath();
+
+        // 인증이 필요 없는 경로들
+        if (path.contains("/auth/signup") ||
+                path.contains("/auth/login") ||
+                path.contains("/users/check")) {
+            return chain.filter(exchange);
+        }
+
         // 헤더에서 'Authorization' 값을 읽어온다.
         String authHeader = exchange.getRequest()
                 .getHeaders()


### PR DESCRIPTION
- JwtAuthenticationFilter에서 /auth/signup, /auth/login, /users/check 경로 예외 처리
- 회원가입 및 중복 확인 API 401 에러 해결
- 기존 인증 로직은 유지하여 다른 기능에 영향 없음